### PR TITLE
Workaround for https://github.com/ziglang/zig/issues/20178

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "zig-set-version",
+    .name = .zig_set_version,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.


### PR DESCRIPTION
Also a `.fingerprint` seems like it should be added, but https://ziglang.org/download/0.14.0/release-notes.html#New-Package-Hash-Format outlines forks should have different fingerprints so didn't seem like it made sense to include as a change from a fork...

Furthermore 0.15.0 seems likely to further break this package with https://github.com/ziglang/zig/issues/20663 so some action should probably be taken there. But the latest zig master seemed to have some internal issue building so I didn't sort through confirming what would build without breaking existing usage.