### PR TITLE
Feature/backward compatibility 0.15.1

### DIFF
--- a/src/operator.zig
+++ b/src/operator.zig
@@ -403,7 +403,13 @@ pub fn readBuildZon(allocator: std.mem.Allocator, full_path: []const u8) ![:0]co
     var buffer: [4096]u8 = undefined;
     var reader = file.reader(&buffer);
     
-    return try reader.interface.allocRemainingAlignedSentinel(allocator, .unlimited, .@"8", 0);
+    if (@hasDecl(std.Io.Reader, "allocRemainingAlignedSentinel")) {
+        return try reader.interface.allocRemainingAlignedSentinel(allocator, .unlimited, .@"8", 0);
+    }
+    else {
+        const size = try reader.getSize();
+        return try file.readToEndAllocOptions(allocator, size, size, .@"8", 0);
+    }
 }
 
 fn readVersionInternal(allocator: std.mem.Allocator, source: [:0]const u8) !std.zig.Token.Loc {


### PR DESCRIPTION
This PR contains following:

- backward compatibility for 0.15.1 

In zig 0.15.1, `std.Io.Reader.allocRemainingAlignedSentinel` is not still supported.
So using `@hasDecl` led to switch it.
