### PR TITLE
Update currentVersion() to take io

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -3,8 +3,8 @@ const op = @import("./operator.zig");
 
 pub const VersionSetterStep = @import("./step.zig");
 
-pub fn currentVersion(allocator: std.mem.Allocator) ![]const u8 {
-    return op.currentVersion(allocator);
+pub fn currentVersion(io: std.Io, allocator: std.mem.Allocator) ![]const u8 {
+    return op.currentVersion(io, allocator);
 }
 
 test "test entry" {


### PR DESCRIPTION
The `op.currentVersion()` was updated to take `io` but not the root proxy.